### PR TITLE
Added new api call plus other changes

### DIFF
--- a/LocalizationUtility/CustomLanguage.cs
+++ b/LocalizationUtility/CustomLanguage.cs
@@ -19,8 +19,13 @@ namespace LocalizationUtility
         {
             Name = name;
             Language = language;
-            TranslationPath = mod.ModHelper.Manifest.ModFolderPath + translationPath;
             LanguageToReplace = languageToReplace;
+
+            if(mod != null)
+            {
+                TranslationPath = mod.ModHelper.Manifest.ModFolderPath + translationPath;
+            }
+            TranslationPath = translationPath;
         }
 
         public void AddFont(string assetBundlePath, string fontPath, ModBehaviour mod)

--- a/LocalizationUtility/ILocalizationAPI.cs
+++ b/LocalizationUtility/ILocalizationAPI.cs
@@ -7,6 +7,7 @@ namespace LocalizationUtility
     {
         void RegisterLanguage(ModBehaviour mod, string name, string translationPath);
         void RegisterLanguage(ModBehaviour mod, string name, string translationPath, string languageToReplace);
+        void AddTranslation(ModBehaviour mod, string name, string translationPath);
         void AddLanguageFont(ModBehaviour mod, string name, string assetBundlePath, string fontPath);
         void AddLanguageFixer(string name, Func<string, string> fixer);
         void SetLanguageDefaultFontSpacing(string name, float defaultFontSpacing);

--- a/LocalizationUtility/LocalizationAPI.cs
+++ b/LocalizationUtility/LocalizationAPI.cs
@@ -9,6 +9,8 @@ namespace LocalizationUtility
             => LocalizationUtility.Instance.RegisterLanguage(mod, name, translationPath, TextTranslation.Language.ENGLISH);
         public void RegisterLanguage(ModBehaviour mod, string name, string translationPath, string languageToReplace)
             => LocalizationUtility.Instance.RegisterLanguage(mod, name, translationPath, (TextTranslation.Language) Enum.Parse(typeof(TextTranslation.Language), languageToReplace, true));
+        public void AddTranslation(ModBehaviour mod, string name, string translationPath)
+            => LocalizationUtility.Instance.AddTranslation(mod, name, translationPath);
         public void AddLanguageFont(ModBehaviour mod, string name, string assetBundlePath, string fontPath)
             => LocalizationUtility.Instance.AddLanguageFont(mod, name, assetBundlePath, fontPath);
         public void AddLanguageFixer(string name, Func<string, string> fixer)

--- a/LocalizationUtility/LocalizationUtility.cs
+++ b/LocalizationUtility/LocalizationUtility.cs
@@ -53,6 +53,20 @@ namespace LocalizationUtility
             WriteError($"The language {language} is null");
             return null;
         }
+        public bool TryGetLanguage(TextTranslation.Language language, out CustomLanguage lang)
+        {
+            lang = null;
+            if (name != null)
+            {
+                CustomLanguage customLanguage = _customLanguages.Values.FirstOrDefault(cl => cl.Language == language);
+                if (customLanguage != null)
+                {
+                    lang = customLanguage;
+                    return true;
+                }
+            }
+            return false;
+        }
 
         public void SetLanguage(string name)
         {

--- a/LocalizationUtility/LocalizationUtility.cs
+++ b/LocalizationUtility/LocalizationUtility.cs
@@ -66,8 +66,11 @@ namespace LocalizationUtility
                 WriteLine($"Registering new language {name}");
 
                 TextTranslation.Language newLanguage = (hasAnyCustomLanguages ? _customLanguages.Values.Max(cl => cl.Language) : vanillaLanguages.Max()) + 1;
-                
-                _customLanguages[name] = new CustomLanguage(name, newLanguage, translationPath, mod, languageToReplace);
+
+                CustomLanguage customLanguage = new CustomLanguage(name, newLanguage, translationPath, mod, languageToReplace);
+                _customLanguages[name] = customLanguage;
+
+                TextTranslationPatches.AddNewTranslation(customLanguage);
             }
             catch(Exception ex)
             {

--- a/LocalizationUtility/Patches/TextTranslationPatches.cs
+++ b/LocalizationUtility/Patches/TextTranslationPatches.cs
@@ -14,19 +14,19 @@ namespace LocalizationUtility
         //Maybe instead of storing TextTranslation.TranslationTable_XML store, which work more like dictionaries TextTranslation.TranslationTable
         private static Dictionary<TextTranslation.Language, TextTranslation.TranslationTable_XML> translationTables = new Dictionary<TextTranslation.Language, TextTranslation.TranslationTable_XML>();
 
-        public static void AddNewTranslation(CustomLanguage language) 
+        public static void AddNewTranslation(CustomLanguage language, string translationPath) 
         {
-            LocalizationUtility.WriteLine($"Storing translation of {language.Language} from {language.TranslationPath}");
+            LocalizationUtility.WriteLine($"Storing translation for {language.Language} from {translationPath}");
             try
             {
                 var xmlDoc = new XmlDocument();
-                xmlDoc.LoadXml(ReadAndRemoveByteOrderMarkFromPath(language.TranslationPath));
+                xmlDoc.LoadXml(ReadAndRemoveByteOrderMarkFromPath(translationPath));
 
                 var translationTableNode = xmlDoc.SelectSingleNode("TranslationTable_XML");
 
                 if (translationTableNode == null)
                 {
-                    LocalizationUtility.WriteError($"TranslationTable_XML could not be found in translation file for language {language.Name}");
+                    LocalizationUtility.WriteError($"TranslationTable_XML could not be found in translation file in {translationPath} for language {language.Name}");
                     return;
                 }
 
@@ -72,7 +72,7 @@ namespace LocalizationUtility
             }
             catch (Exception e)
             {
-                LocalizationUtility.WriteError($"Couldn't load translation for language {language.Name}: {e.Message}{e.StackTrace}");
+                LocalizationUtility.WriteError($"Couldn't load translation for language {language.Name} from file in {translationPath}: {e.Message}{e.StackTrace}");
             }
         }
 

--- a/LocalizationUtility/Patches/TextTranslationPatches.cs
+++ b/LocalizationUtility/Patches/TextTranslationPatches.cs
@@ -131,11 +131,11 @@ namespace LocalizationUtility
             {
                 return;
             }
-
-            LocalizationUtility.WriteLine($"Loading aditional translations for {language.Name}");
             
             if (translationTables.TryGetValue(lang, out var table))
             {
+                LocalizationUtility.WriteLine($"Loading aditional translations for {language.Name}");
+
                 foreach (var pair in table.table)
                     __instance.m_table.theTable[pair.key] = pair.value;
 


### PR DESCRIPTION
* Made it [join translation tables from multiple mods for the same languages](https://github.com/ShoosGun/outer-wilds-localization-utility/blob/457a2df84809aa082bdc538a420267fe51df78a0/LocalizationUtility/Patches/TextTranslationPatches.cs#L33), being them custom or vanilla.

* Added the api call [`AddTranslation`](https://github.com/ShoosGun/outer-wilds-localization-utility/blob/c1eeda080c1f7aab7e2c897d409208073d59c743/LocalizationUtility/LocalizationAPI.cs#L12).

* Made the mod "see" the vanilla languages as ["custom languages"](https://github.com/ShoosGun/outer-wilds-localization-utility/blob/c1eeda080c1f7aab7e2c897d409208073d59c743/LocalizationUtility/LocalizationUtility.cs#L176).

* Changed how it loads translation tables by first [caching them in a dictionary](https://github.com/ShoosGun/outer-wilds-localization-utility/blob/457a2df84809aa082bdc538a420267fe51df78a0/LocalizationUtility/Patches/TextTranslationPatches.cs#L15), and then [appending/editing the game's translation table on the prefix/postfix](https://github.com/ShoosGun/outer-wilds-localization-utility/blob/457a2df84809aa082bdc538a420267fe51df78a0/LocalizationUtility/Patches/TextTranslationPatches.cs#L102).

* Made other changes I can't really remember.