### PR TITLE
0.3.2

### DIFF
--- a/LocalizationUtility/CustomLanguage.cs
+++ b/LocalizationUtility/CustomLanguage.cs
@@ -81,8 +81,8 @@ namespace LocalizationUtility
 				// Add regular text to the table
 				foreach (XmlNode node in translationTableNode.SelectNodes("entry"))
 				{
-					var key = node.SelectSingleNode("key").InnerText;
-					var value = node.SelectSingleNode("value").InnerText;
+					var key = node.SelectSingleNode("key").InnerText.Trim();
+					var value = node.SelectSingleNode("value").InnerText.Trim();
 
 					if (Fixer != null) value = Fixer(value);
 

--- a/LocalizationUtility/Patches/TextTranslationPatches.cs
+++ b/LocalizationUtility/Patches/TextTranslationPatches.cs
@@ -145,7 +145,8 @@ namespace LocalizationUtility
                 return false;
             }
 
-            string text = __instance.m_table.Get(key);
+			// Whitespace issues are really annoying so we try to be more forgiving
+            string text = __instance.m_table.Get(key) ?? __instance.m_table.Get(key.Trim());
             if (text == null)
             {
                 LocalizationUtility.WriteError($"String \"{key}\" not found in table for language {LocalizationUtility.Instance.GetLanguage(__instance.m_language).Name}");

--- a/LocalizationUtility/manifest.json
+++ b/LocalizationUtility/manifest.json
@@ -4,7 +4,7 @@
 	"author": "xen",
 	"name": "Interplanetary Polyglot",
 	"uniqueName": "xen.LocalizationUtility",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"owmlVersion": "2.9.8",
 	"donateLink": "https://www.patreon.com/xen42"
 }


### PR DESCRIPTION
- Whitespace is now trimmed from translation keys, means the formatting of a Translation.xml file is more forgiving.